### PR TITLE
Mirror of apache tinkerpop#941

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/TranslatorCustomizer.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/jsr223/TranslatorCustomizer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tinkerpop.gremlin.jsr223;
+
+import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.Translator;
+
+/**
+ * Provides a way to customize and override {@link Bytecode} to script translation. Not all {@link GremlinScriptEngine}
+ * will support this capability as translation is optional.
+ *
+ * @author Stephen Mallette (http://stephen.genoprime.com)
+ */
+public interface TranslatorCustomizer extends Customizer {
+
+    /**
+     * Construct a {@link Translator.ScriptTranslator.TypeTranslator} that will be used by a
+     * {@link Translator.ScriptTranslator} instance within the {@link GremlinScriptEngine} to translate
+     * {@link Bytecode} to a script.
+     */
+    public Translator.ScriptTranslator.TypeTranslator createTypeTranslator();
+}

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Translator.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/Translator.java
@@ -19,6 +19,8 @@
 
 package org.apache.tinkerpop.gremlin.process.traversal;
 
+import java.util.function.UnaryOperator;
+
 /**
  * A Translator will translate {@link Bytecode} into another representation. That representation may be a
  * Java instance via {@link StepTranslator} or a String script in some language via {@link ScriptTranslator}.
@@ -55,10 +57,42 @@ public interface Translator<S, T> {
 
     ///
 
+    /**
+     * Translates bytecode to a string representation.
+     */
     public interface ScriptTranslator extends Translator<String, String> {
 
+        /**
+         * Provides a way to customize and override the standard translation process. A {@link ScriptTranslator}
+         * implementation can choose to expose a way to accept a {@code TypeTranslator} which will convert an incoming
+         * object to a different form which will then be normally processed or can return a {@link Handled} object
+         * with the already translated script.
+         */
+        public interface TypeTranslator extends UnaryOperator<Object> {
+            public static TypeTranslator identity() {
+                return t -> t;
+            }
+        }
+
+        /**
+         * Contains a completed type translation from the {@link TypeTranslator}.
+         */
+        public class Handled {
+            private final String translation;
+
+            public Handled(final String translation) {
+                this.translation = translation;
+            }
+
+            public String getTranslation() {
+                return translation;
+            }
+        }
     }
 
+    /**
+     * Translates bytecode to actual steps.
+     */
     public interface StepTranslator<S extends TraversalSource, T extends Traversal.Admin<?, ?>> extends Translator<S, T> {
 
     }

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslatorTest.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslatorTest.java
@@ -22,6 +22,7 @@ package org.apache.tinkerpop.gremlin.groovy.jsr223;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.process.traversal.Translator;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -32,47 +33,56 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.Transl
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategy;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge;
 import org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex;
 import org.apache.tinkerpop.gremlin.util.function.Lambda;
 import org.junit.Test;
 
 import javax.script.Bindings;
+import javax.script.ScriptException;
 import javax.script.SimpleBindings;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Function;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
  */
 public class GroovyTranslatorTest extends AbstractGremlinTest {
 
+    private static final GremlinGroovyScriptEngine engine = new GremlinGroovyScriptEngine();
+
     @Test
     @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
     public void shouldHandleStrategies() throws Exception {
-        GraphTraversalSource g = graph.traversal();
-        g = g.withStrategies(SubgraphStrategy.create(new MapConfiguration(new HashMap<String, Object>() {{
+        final GraphTraversalSource g = graph.traversal().withStrategies(SubgraphStrategy.create(new MapConfiguration(new HashMap<String, Object>() {{
             put(SubgraphStrategy.VERTICES, __.has("name", "marko"));
         }})));
         final Bindings bindings = new SimpleBindings();
         bindings.put("g", g);
-        Traversal.Admin<Vertex, Object> traversal = new GremlinGroovyScriptEngine().eval(g.V().values("name").asAdmin().getBytecode(), bindings, "g");
+        Traversal.Admin<Vertex, Object> traversal = engine.eval(g.V().values("name").asAdmin().getBytecode(), bindings, "g");
         assertEquals("marko", traversal.next());
         assertFalse(traversal.hasNext());
         //
-        traversal = new GremlinGroovyScriptEngine().eval(g.withoutStrategies(SubgraphStrategy.class).V().count().asAdmin().getBytecode(), bindings, "g");
+        traversal = engine.eval(g.withoutStrategies(SubgraphStrategy.class).V().count().asAdmin().getBytecode(), bindings, "g");
         assertEquals(new Long(6), traversal.next());
         assertFalse(traversal.hasNext());
         //
-        traversal = new GremlinGroovyScriptEngine().eval(g.withStrategies(SubgraphStrategy.create(new MapConfiguration(new HashMap<String, Object>() {{
+        traversal = engine.eval(g.withStrategies(SubgraphStrategy.create(new MapConfiguration(new HashMap<String, Object>() {{
             put(SubgraphStrategy.VERTICES, __.has("name", "marko"));
         }})), ReadOnlyStrategy.instance()).V().values("name").asAdmin().getBytecode(), bindings, "g");
         assertEquals("marko", traversal.next());
@@ -81,10 +91,10 @@ public class GroovyTranslatorTest extends AbstractGremlinTest {
 
     @Test
     @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
-    public void shouldSupportStringSupplierLambdas() throws Exception {
+    public void shouldSupportStringSupplierLambdas() {
         GraphTraversalSource g = graph.traversal();
         g = g.withStrategies(new TranslationStrategy(g, GroovyTranslator.of("g")));
-        GraphTraversal.Admin<Vertex, Integer> t = g.withSideEffect("lengthSum", 0).withSack(1)
+        final GraphTraversal.Admin<Vertex, Integer> t = g.withSideEffect("lengthSum", 0).withSack(1)
                 .V()
                 .filter(Lambda.predicate("it.get().label().equals('person')"))
                 .flatMap(Lambda.function("it.get().vertices(Direction.OUT)"))
@@ -130,25 +140,77 @@ public class GroovyTranslatorTest extends AbstractGremlinTest {
                         ".order().by({a,b -> a <=> b})" +
                         ".sack({ a,b -> a + b })",
                 script);
+        assertThatScriptOk(script, "g", g);
     }
 
     @Test
     @LoadGraphWith(LoadGraphWith.GraphData.MODERN)
     public void shouldHandleMaps() {
-        final GraphTraversalSource g = graph.traversal();
         final String script = GroovyTranslator.of("g").translate(g.V().id().is(new LinkedHashMap<Object,Object>() {{
             put(3, "32");
             put(Arrays.asList(1, 2, 3.1d), 4);
         }}).asAdmin().getBytecode());
         assertEquals("g.V().id().is([((int) 3):(\"32\"),([(int) 1, (int) 2, 3.1d]):((int) 4)])", script);
+        assertThatScriptOk(script, "g", g);
     }
 
     @Test
     public void shouldHandleEmptyMaps() {
         final Function identity = new Lambda.OneArgLambda("it.get()", "gremlin-groovy");
-        final GraphTraversalSource g = graph.traversal();
         final String script = GroovyTranslator.of("g").translate(g.inject(Collections.emptyMap()).map(identity).asAdmin().getBytecode());
         assertEquals("g.inject([]).map({it.get()})", script);
+        assertThatScriptOk(script, "g", g);
+    }
+
+    @Test
+    public void shouldHandleDate() {
+        final Calendar c = Calendar.getInstance();
+        c.set(1975, Calendar.SEPTEMBER, 7);
+        final Date d = c.getTime();
+        assertTranslation(String.format("new java.util.Date(%s)", d.getTime()), d);
+    }
+
+    @Test
+    public void shouldHandleTimestamp() {
+        final Calendar c = Calendar.getInstance();
+        c.set(1975, Calendar.SEPTEMBER, 7);
+        final Timestamp t = new Timestamp(c.getTime().getTime());
+        assertTranslation(String.format("new java.sql.Timestamp(%s)", t.getTime()), t);
+    }
+
+    @Test
+    public void shouldHandleUuid() {
+        final UUID uuid = UUID.fromString("ffffffff-fd49-1e4b-0000-00000d4b8a1d");
+        assertTranslation(String.format("java.util.UUID.fromString('%s')", uuid), uuid);
+    }
+
+    @Test
+    public void shouldOverrideDefaultTypeTranslationWithSomethingBonkers() {
+        final String thingToSuffixAllStringsWith = "-why-would-anyone-do-this";
+        final String script = GroovyTranslator.of("g", x -> x instanceof String ? x + thingToSuffixAllStringsWith : x).
+                translate(g.inject("yyy", "xxx").asAdmin().getBytecode());
+        assertEquals(String.format("g.inject(\"yyy%s\",\"xxx%s\")", thingToSuffixAllStringsWith, thingToSuffixAllStringsWith), script);
+        assertThatScriptOk(script, "g", g);
+    }
+
+    @Test
+    public void shouldIncludeCustomTypeTranslationForSomethingSilly() {
+        final SillyClass notSillyEnough = SillyClass.from("not silly enough", 100);
+        final GraphTraversalSource g = graph.traversal();
+
+        // without type translation we get uglinesss
+        final String scriptBad = GroovyTranslator.of("g").
+                translate(g.inject(notSillyEnough).asAdmin().getBytecode());
+        assertEquals(String.format("g.inject(%s)", "not silly enough:100"), scriptBad);
+
+        // with type translation we get valid gremlin
+        final String scriptGood = GroovyTranslator.of("g",
+                x -> x instanceof SillyClass ?
+                        new Translator.ScriptTranslator.Handled(String.format("org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyTranslatorTest.SillyClass.from('%s', (int) %s)",
+                        ((SillyClass) x).getX(), ((SillyClass) x).getY())) : x).
+                translate(g.inject(notSillyEnough).asAdmin().getBytecode());
+        assertEquals(String.format("g.inject(org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyTranslatorTest.SillyClass.from('%s', (int) %s))", notSillyEnough.getX(), notSillyEnough.getY()), scriptGood);
+        assertThatScriptOk(scriptGood, "g", g);
     }
 
     @Test
@@ -158,20 +220,8 @@ public class GroovyTranslatorTest extends AbstractGremlinTest {
 
     @Test
     public void shouldEscapeStrings() {
-        final GraphTraversalSource g = graph.traversal();
-        final String script = GroovyTranslator.of("g").translate(g.addV("customer")
-                .property("customer_id", 501L)
-                .property("name", "Foo\u0020Bar")
-                .property("age", 25)
-                .property("special", "`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?")
-                .asAdmin().getBytecode());
-
-        assertEquals("g.addV(\"customer\")" +
-                        ".property(\"customer_id\",501L)" +
-                        ".property(\"name\",\"Foo Bar\")" +
-                        ".property(\"age\",(int) 25)" +
-                        ".property(\"special\",\"\"\"`~!@#\\$%^&*()-_=+[{]}\\\\|;:'\\\",<.>/?\"\"\")",
-                script);
+        assertTranslation("501L,\"Foo Bar\",(int) 25,\"\"\"`~!@#\\$%^&*()-_=+[{]}\\\\|;:'\\\",<.>/?\"\"\"",
+                501L, "Foo\u0020Bar", 25, "`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/?");
     }
 
     @Test
@@ -181,33 +231,87 @@ public class GroovyTranslatorTest extends AbstractGremlinTest {
         final Object id1 = "customer:10:foo\u0020bar\u0020\u0024100#90"; // customer:10:foo bar $100#90
         final Vertex vertex1 = DetachedVertex.build().setLabel("customer").setId(id1)
                 .create();
-        final String script1 = GroovyTranslator.of("g").translate(g.V(vertex1).asAdmin().getBytecode());
-        assertEquals("g.V(new org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex(" +
+        final String script1 = GroovyTranslator.of("g").translate(g.inject(vertex1).asAdmin().getBytecode());
+        assertEquals("g.inject(new org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex(" +
                         "\"customer:10:foo bar \\$100#90\"," +
                         "\"customer\", Collections.emptyMap()))",
                 script1);
+        assertThatScriptOk(script1, "g", g);
 
         final Object id2 = "user:20:foo\\u0020bar\\u005c\\u0022mr\\u005c\\u0022\\u00241000#50"; // user:20:foo\u0020bar\u005c\u0022mr\u005c\u0022\u00241000#50
         final Vertex vertex2 = DetachedVertex.build().setLabel("user").setId(id2)
                 .create();
-        final String script2 = GroovyTranslator.of("g").translate(g.V(vertex2).asAdmin().getBytecode());
-        assertEquals("g.V(new org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex(" +
+        final String script2 = GroovyTranslator.of("g").translate(g.inject(vertex2).asAdmin().getBytecode());
+        assertEquals("g.inject(new org.apache.tinkerpop.gremlin.structure.util.detached.DetachedVertex(" +
                         "\"user:20:foo\\\\u0020bar\\\\u005c\\\\u0022mr\\\\u005c\\\\u0022\\\\u00241000#50\"," +
                         "\"user\", Collections.emptyMap()))",
                 script2);
+        assertThatScriptOk(script2, "g", g);
 
         final Object id3 = "knows:30:foo\u0020bar\u0020\u0024100:\\u0020\\u0024500#70";
         final Edge edge = DetachedEdge.build().setLabel("knows").setId(id3)
                 .setOutV((DetachedVertex) vertex1)
                 .setInV((DetachedVertex) vertex2)
                 .create();
-        final String script3 = GroovyTranslator.of("g").translate(g.E(edge).asAdmin().getBytecode());
-        assertEquals("g.E(new org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge(" +
+        final String script3 = GroovyTranslator.of("g").translate(g.inject(edge).asAdmin().getBytecode());
+        assertEquals("g.inject(new org.apache.tinkerpop.gremlin.structure.util.detached.DetachedEdge(" +
                         "\"knows:30:foo bar \\$100:\\\\u0020\\\\u0024500#70\"," +
                         "\"knows\",Collections.emptyMap()," +
                         "\"customer:10:foo bar \\$100#90\",\"customer\"," +
                         "\"user:20:foo\\\\u0020bar\\\\u005c\\\\u0022mr\\\\u005c\\\\u0022\\\\u00241000#50\",\"user\"))",
                 script3);
+        assertThatScriptOk(script3, "g", g);
+    }
+
+    public static Object eval(final String s, final Object... args) throws ScriptException {
+        return engine.eval(s, new SimpleBindings(ElementHelper.asMap(args)));
+    }
+
+    public static Object eval(final String s, final Bindings b) throws ScriptException {
+        return engine.eval(s, b);
+    }
+
+    private void assertTranslation(final String expectedTranslation, final Object... objs) {
+        final String script = GroovyTranslator.of("g").translate(g.inject(objs).asAdmin().getBytecode());
+        assertEquals(String.format("g.inject(%s)", expectedTranslation), script);
+        assertThatScriptOk(script, "g", g);
+    }
+
+    private void assertThatScriptOk(final String s, final Object... args) {
+        try {
+            assertNotNull(eval(s, args));
+        } catch (ScriptException se) {
+            se.printStackTrace();
+            fail("Script should have eval'd");
+        }
+    }
+
+    public static class SillyClass {
+
+        private final String x;
+        private final int y;
+
+        private SillyClass(final String x, final int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        public static SillyClass from(final String x, final int y) {
+            return new SillyClass(x, y);
+        }
+
+        public String getX() {
+            return x;
+        }
+
+        public int getY() {
+            return y;
+        }
+
+        @Override
+        public String toString() {
+            return x + ":" + String.valueOf(y);
+        }
     }
 
 }

--- a/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslatorTest.java
+++ b/gremlin-groovy-test/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslatorTest.java
@@ -22,6 +22,9 @@ package org.apache.tinkerpop.gremlin.groovy.jsr223;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.tinkerpop.gremlin.AbstractGremlinTest;
 import org.apache.tinkerpop.gremlin.LoadGraphWith;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.Pop;
+import org.apache.tinkerpop.gremlin.process.traversal.Scope;
 import org.apache.tinkerpop.gremlin.process.traversal.Translator;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
@@ -31,6 +34,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SubgraphStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.TranslationStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategy;
+import org.apache.tinkerpop.gremlin.structure.Column;
+import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
@@ -182,6 +187,31 @@ public class GroovyTranslatorTest extends AbstractGremlinTest {
     public void shouldHandleUuid() {
         final UUID uuid = UUID.fromString("ffffffff-fd49-1e4b-0000-00000d4b8a1d");
         assertTranslation(String.format("java.util.UUID.fromString('%s')", uuid), uuid);
+    }
+
+    @Test
+    public void shouldHandleColumn() {
+        assertTranslation("Column.keys", Column.keys);
+    }
+
+    @Test
+    public void shouldHandleDirection() {
+        assertTranslation("Direction.BOTH", Direction.BOTH);
+    }
+
+    @Test
+    public void shouldHandleOrder() {
+        assertTranslation("Order.decr", Order.decr);
+    }
+
+    @Test
+    public void shouldHandlePop() {
+        assertTranslation("Pop.last", Pop.last);
+    }
+
+    @Test
+    public void shouldHandleScope() {
+        assertTranslation("Scope.local", Scope.local);
     }
 
     @Test

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
@@ -22,7 +22,9 @@ package org.apache.tinkerpop.gremlin.groovy.jsr223;
 import groovy.json.StringEscapeUtils;
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 import org.apache.tinkerpop.gremlin.process.traversal.SackFunctions;
 import org.apache.tinkerpop.gremlin.process.traversal.Translator;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -32,6 +34,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalOptionParent
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.TraversalStrategyProxy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.OrP;
+import org.apache.tinkerpop.gremlin.structure.Column;
+import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;

--- a/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
+++ b/gremlin-groovy/src/main/java/org/apache/tinkerpop/gremlin/groovy/jsr223/GroovyTranslator.java
@@ -22,9 +22,7 @@ package org.apache.tinkerpop.gremlin.groovy.jsr223;
 import groovy.json.StringEscapeUtils;
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
-import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
-import org.apache.tinkerpop.gremlin.process.traversal.Pop;
 import org.apache.tinkerpop.gremlin.process.traversal.SackFunctions;
 import org.apache.tinkerpop.gremlin.process.traversal.Translator;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -34,8 +32,6 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.TraversalOptionParent
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.TraversalStrategyProxy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.OrP;
-import org.apache.tinkerpop.gremlin.structure.Column;
-import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -52,10 +48,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.UnaryOperator;
 
 /**
+ * Converts bytecode to a Groovy string of Gremlin.
+ *
  * @author Marko A. Rodriguez (http://markorodriguez.com)
+ * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public final class GroovyTranslator implements Translator.ScriptTranslator {
 


### PR DESCRIPTION
Mirror of apache tinkerpop#941
https://issues.apache.org/jira/browse/TINKERPOP-2040

Handled all of the core GraphSON types in the `GroovyTranslator`. Included a new `TypeTranslator` to allow the behavior of the `ScriptTranslator` to be modified and allowed the `GremlinGroovyScriptEngine` to accept a `TranslatorCustomizer` to allow that custom `TypeTranslator` to be used.

All tests pass with `docker/build.sh -t -i`

VOTE +1
